### PR TITLE
Fixing issue #17 (Map keys are mangled when retrieved)

### DIFF
--- a/cassandra_statement.cpp
+++ b/cassandra_statement.cpp
@@ -465,9 +465,9 @@ zval* parse_collection_map(const std::string &type, const std::string &data) {
             if (elt_types[0] == PDO_CASSANDRA_TYPE_ASCII ||
                 elt_types[0] == PDO_CASSANDRA_TYPE_UTF8) {
                 // String key case
-                char *str = (char *)emalloc(sizeof(*str) * value_size);
-                memcpy(str, datap, value_size + 1);
-                str[value_size] = 0;
+                char *str = (char *)emalloc(sizeof(*str) * key_size);
+                memcpy(str, datap, key_size + 1);
+                str[key_size] = 0;
                 add_assoc_zval(collection, str, value);
             } else {
                 // Numeric keys case

--- a/tests/034-collections.phpt
+++ b/tests/034-collections.phpt
@@ -24,7 +24,7 @@ $db->exec ("CREATE COLUMNFAMILY cf (my_key int PRIMARY KEY,
 
 // Map varchar int test
 $db->exec("INSERT INTO cf (my_key, map_test_vc_int)
-		VALUES (400, {'key1': 1, 'key2': 2, 'key3': 3});");
+		VALUES (400, {'key_1': 1, 'key_2': 2, 'looong_key_here': 3});");
 print_r($db->query('SELECT map_test_vc_int FROM cf WHERE my_key=400;')->fetchObject());
 
 
@@ -51,9 +51,9 @@ stdClass Object
 (
     [map_test_vc_int] => Array
         (
-            [key1] => 1
-            [key2] => 2
-            [key3] => 3
+            [key_1] => 1
+            [key_2] => 2
+            [looong_key_here] => 3
         )
 
 )


### PR DESCRIPTION
Map byte stream parsing fix (use key_size for keys instead of value_size)
Modified map test to use longer string keys.
