### PR TITLE
Be able to compile YACassandra statically into PHP

### DIFF
--- a/php_pdo_cassandra.hpp
+++ b/php_pdo_cassandra.hpp
@@ -20,6 +20,7 @@
 #define PHP_PDO_CASSANDRA_EXTNAME "pdo_cassandra"
 #define PHP_PDO_CASSANDRA_EXTVER "0.4.3"
 
+#ifdef __cplusplus
 extern "C" {
 #ifdef ZTS
 # include "TSRM.h"
@@ -27,8 +28,9 @@ extern "C" {
 
 #include "php.h"
 }
+#endif
 
-extern zend_module_entry cassandra_module_entry;
-#define phpext_cassandra_ptr &cassandra_module_entry
+extern zend_module_entry pdo_cassandra_module_entry;
+#define phpext_pdo_cassandra_ptr &pdo_cassandra_module_entry
 
 #endif /* _PHP_PDO_CASSANDRA_H_ */

--- a/php_pdo_cassandra_int.hpp
+++ b/php_pdo_cassandra_int.hpp
@@ -47,9 +47,9 @@ extern "C" {
 #undef HAVE_ZLIB
 
 #include "gen-cpp/Cassandra.h"
-#include <protocol/TBinaryProtocol.h>
-#include <transport/TSocketPool.h>
-#include <transport/TTransportUtils.h>
+#include <thrift/protocol/TBinaryProtocol.h>
+#include <thrift/transport/TSocketPool.h>
+#include <thrift/transport/TTransportUtils.h>
 
 #undef HAVE_ZLIB
 #define HAVE_ZLIB HAVE_ZLIB_CP


### PR DESCRIPTION
Compilation of YACassandraPDO fail if you compile it statically inside php (http://www.php.net/manual/en/install.pecl.static.php).
This patch allow compilation of php via : 
./buildconf --force
./configure --enable-pdo --with-pdo-cassandra=ext/pdo_cassandra/interface/cassandra.thrift

Readme should be updated too to add the correct command line.
I'm not a m4 expert, so maybe there is a better solution instead of adding  --with-pdo-cassandra=ext/pdo_cassandra/interface/cassandra.thrift

Note that folder need to be named "pdo_cassandra" (e.g phpsource-5.4.x/ext/pdo_cassandra/).
