### PR TITLE
issue #30: timestamp type is returns as bytestring rather than int.

### DIFF
--- a/cassandra_statement.cpp
+++ b/cassandra_statement.cpp
@@ -222,7 +222,8 @@ static pdo_cassandra_type pdo_cassandra_get_cassandra_type(const std::string &ty
         return PDO_CASSANDRA_TYPE_INTEGER;
     if (!real_type.compare("LongType") ||
         !real_type.compare("DateType") ||
-        !real_type.compare("CounterColumnType"))
+        !real_type.compare("CounterColumnType") ||
+	!real_type.compare("TimestampType"))
         return PDO_CASSANDRA_TYPE_LONG;
     if (!real_type.compare("BooleanType"))
         return PDO_CASSANDRA_TYPE_BOOLEAN;


### PR DESCRIPTION
TimestampType was not considered in the function pdo_cassandra_get_cassandra_type
