### PR TITLE
Use correct call in PDO_CASSANDRA_ATTR_RANDOMIZE

### DIFF
--- a/cassandra_driver.cpp
+++ b/cassandra_driver.cpp
@@ -656,7 +656,7 @@ static int pdo_cassandra_handle_set_attribute(pdo_dbh_t *dbh, long attr, zval *v
 
         case PDO_CASSANDRA_ATTR_RANDOMIZE:
             convert_to_boolean(val);
-            H->socket->setMaxConsecutiveFailures(Z_BVAL_P(val));
+            H->socket->setRandomize(Z_BVAL_P(val));
         break;
 
         case PDO_CASSANDRA_ATTR_ALWAYS_TRY_LAST:


### PR DESCRIPTION
Use setRandomize() call instead of setMaxConsecutiveFailures() in
PDO_CASSANDRA_ATTR_RANDOMIZE case.

PDO_CASSANDRA_ATTR_RANDOMIZE doesn't works because it call the wrong thrift function.

Furthermore, I have a problem when I initialize a pdo connection with several servers, the driver always connect to the same "random" host. Randomize might be broken on thrift cpp side (lib/cpp/src/thrift/transport/TSocketPool.cpp, no salt initialisation ?), so random_shuffle always return the same result. Need to dig deeper though.
