### PR TITLE
SSL support for client-server communication using Thrift SSL socket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Before make test:
     $ cp tests/config.inc-dist tests/config.inc
     $ $EDITOR tests/config.inc
 
-For running tests with SSL configuration, use $params in config.inc for setting certificate path, private/public key etc. 
-
 This is to prevent accidentally dropping keyspaces that might in use.
+
+For running tests with SSL configuration, use $params in config.inc for setting certificate path, private/public key etc. 
 
 # Create a debian package from the sources
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Before make test:
     $ cp tests/config.inc-dist tests/config.inc
     $ $EDITOR tests/config.inc
 
+For running tests with SSL configuration, use $params in config.inc for setting certificate path, private/public key etc. 
+
 This is to prevent accidentally dropping keyspaces that might in use.
 
 # Create a debian package from the sources

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Before make test:
 
 This is to prevent accidentally dropping keyspaces that might in use.
 
-For running tests with SSL configuration, use $params in config.inc for setting certificate path, private/public key etc. 
+For running tests with SSL configuration, use $params in config.inc for setting certificate path, private/public key etc.
 
 # Create a debian package from the sources
 

--- a/cassandra_statement.cpp
+++ b/cassandra_statement.cpp
@@ -51,6 +51,8 @@ static zend_bool pdo_cassandra_describe_keyspace(pdo_stmt_t *stmt TSRMLS_DC)
         pdo_cassandra_error(stmt->dbh, PDO_CASSANDRA_AUTHORIZATION_ERROR, "%s", e.why.c_str());
     } catch (SchemaDisagreementException &e) {
         pdo_cassandra_error(stmt->dbh, PDO_CASSANDRA_SCHEMA_DISAGREEMENT, "%s", e.what());
+    } catch (TSSLException &e) {
+        pdo_cassandra_error_exception(stmt->dbh, PDO_CASSANDRA_SSL_ERROR, "%s", e.what());
     } catch (TTransportException &e) {
         pdo_cassandra_error(stmt->dbh, PDO_CASSANDRA_TRANSPORT_ERROR, "%s", e.what());
     } catch (TException &e) {
@@ -123,6 +125,8 @@ static int pdo_cassandra_stmt_execute(pdo_stmt_t *stmt TSRMLS_DC)
         pdo_cassandra_error(stmt->dbh, PDO_CASSANDRA_AUTHORIZATION_ERROR, "%s", e.why.c_str());
     } catch (SchemaDisagreementException &e) {
         pdo_cassandra_error(stmt->dbh, PDO_CASSANDRA_SCHEMA_DISAGREEMENT, "%s", e.what());
+    } catch (TSSLException &e) {
+        pdo_cassandra_error_exception(stmt->dbh, PDO_CASSANDRA_SSL_ERROR, "%s", e.what());
     } catch (TTransportException &e) {
         pdo_cassandra_error(stmt->dbh, PDO_CASSANDRA_TRANSPORT_ERROR, "%s", e.what());
     } catch (TException &e) {

--- a/php_pdo_cassandra_int.hpp
+++ b/php_pdo_cassandra_int.hpp
@@ -15,7 +15,7 @@
  */
 
 #ifndef _PHP_PDO_CASSANDRA_PRIVATE_H_
-# define _PHP_PDO_CASSANDRA_PRIVATE_H_
+#define _PHP_PDO_CASSANDRA_PRIVATE_H_
 
 #ifndef CASSANDRA_CQL_VERSION
 #define CASSANDRA_CQL_VERSION "3.0.0"
@@ -50,6 +50,7 @@ extern "C" {
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/transport/TSocketPool.h>
 #include <thrift/transport/TTransportUtils.h>
+#include <thrift/transport/TSSLSocket.h>
 
 #undef HAVE_ZLIB
 #define HAVE_ZLIB HAVE_ZLIB_CP
@@ -103,6 +104,8 @@ typedef struct {
 typedef struct {
     zend_object zo;
     zend_bool compression;
+    boost::shared_ptr<TSSLSocketFactory> factory;
+    boost::shared_ptr<TSSLSocket> sslSocket;
     boost::shared_ptr<TSocketPool> socket;
     boost::shared_ptr<TFramedTransport> transport;
     boost::shared_ptr<TProtocol> protocol;
@@ -114,6 +117,7 @@ typedef struct {
     KsDef description;
     zend_bool has_description;
     zend_bool preserve_values;
+    zend_bool ssl;
     ConsistencyLevel::type consistency;
     ConsistencyLevel::type tmpConsistency;
 } pdo_cassandra_db_handle;
@@ -152,7 +156,13 @@ enum pdo_cassandra_constant {
     PDO_CASSANDRA_ATTR_THRIFT_DEBUG,
     PDO_CASSANDRA_ATTR_PRESERVE_VALUES,
     PDO_CASSANDRA_ATTR_MAX,
-    PDO_CASSANDRA_ATTR_CONSISTENCYLEVEL
+    PDO_CASSANDRA_ATTR_CONSISTENCYLEVEL,
+    PDO_CASSANDRA_ATTR_SSL_KEY,
+    PDO_CASSANDRA_ATTR_SSL_CERT,
+    PDO_CASSANDRA_ATTR_SSL_CAPATH,
+    PDO_CASSANDRA_ATTR_SSL_VALIDATE,
+    PDO_CASSANDRA_ATTR_SSL_VERIFY_HOST,
+    PDO_CASSANDRA_ATTR_SSL_CIPHER
 
 };
 /* }}} */
@@ -180,6 +190,7 @@ enum pdo_cassandra_error {
     PDO_CASSANDRA_AUTHORIZATION_ERROR,
     PDO_CASSANDRA_SCHEMA_DISAGREEMENT,
     PDO_CASSANDRA_TRANSPORT_ERROR,
+    PDO_CASSANDRA_SSL_ERROR,
     PDO_CASSANDRA_INVALID_CONNECTION_STRING,
     PDO_CASSANDRA_INTEGER_CONVERSION_ERROR
 };
@@ -192,4 +203,11 @@ void pdo_cassandra_set_active_keyspace(pdo_cassandra_db_handle *H, const std::st
 void pdo_cassandra_set_active_columnfamily(pdo_cassandra_db_handle *H, const std::string &query TSRMLS_DC);
 std::string pdo_cassandra_get_first_sub_pattern(const std::string &subject, const std::string &pattern TSRMLS_DC);
 
+class NoHostVerificationAccessManager: public AccessManager {
+public:
+    // AccessManager interface
+    Decision verify(const sockaddr_storage& sa) throw();
+    Decision verify(const std::string& host, const char* name, int size) throw();
+    Decision verify(const sockaddr_storage& sa, const char* data, int size) throw();
+};
 #endif /* _PHP_PDO_CASSANDRA_PRIVATE_H_ */

--- a/php_pdo_cassandra_int.hpp
+++ b/php_pdo_cassandra_int.hpp
@@ -64,6 +64,8 @@ using namespace apache::thrift::protocol;
 using namespace apache::thrift::transport;
 using namespace org::apache::cassandra;
 
+class PasswordCallbackTSSLSocketFactory;
+
 enum pdo_cassandra_type {
     PDO_CASSANDRA_TYPE_UTF8 = PDO_PARAM_STR,
     PDO_CASSANDRA_TYPE_INTEGER = PDO_PARAM_INT,
@@ -104,7 +106,7 @@ typedef struct {
 typedef struct {
     zend_object zo;
     zend_bool compression;
-    boost::shared_ptr<TSSLSocketFactory> factory;
+    boost::shared_ptr<PasswordCallbackTSSLSocketFactory> factory;
     boost::shared_ptr<TSSLSocket> sslSocket;
     boost::shared_ptr<TSocketPool> socket;
     boost::shared_ptr<TFramedTransport> transport;
@@ -158,6 +160,7 @@ enum pdo_cassandra_constant {
     PDO_CASSANDRA_ATTR_MAX,
     PDO_CASSANDRA_ATTR_CONSISTENCYLEVEL,
     PDO_CASSANDRA_ATTR_SSL_KEY,
+    PDO_CASSANDRA_ATTR_SSL_KEY_PASSPHRASE,
     PDO_CASSANDRA_ATTR_SSL_CERT,
     PDO_CASSANDRA_ATTR_SSL_CAPATH,
     PDO_CASSANDRA_ATTR_SSL_VALIDATE,
@@ -209,5 +212,16 @@ public:
     Decision verify(const sockaddr_storage& sa) throw();
     Decision verify(const std::string& host, const char* name, int size) throw();
     Decision verify(const sockaddr_storage& sa, const char* data, int size) throw();
+};
+
+class PasswordCallbackTSSLSocketFactory: public TSSLSocketFactory {
+public:
+    void setPassword(const char *passphrase) {
+       sslkeyPassphrase_ = passphrase;
+    }
+protected:
+    void getPassword(std::string& /* password */, int /* size */);
+private:
+    std::string sslkeyPassphrase_;
 };
 #endif /* _PHP_PDO_CASSANDRA_PRIVATE_H_ */

--- a/tests/001-construct.phpt
+++ b/tests/001-construct.phpt
@@ -7,7 +7,7 @@ Test pdo cassandra construction
 
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 echo "OK";
 

--- a/tests/002-select.phpt
+++ b/tests/002-select.phpt
@@ -6,7 +6,7 @@ Test prepared statement emulation
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init ($db, $keyspace);
 

--- a/tests/003-transaction.phpt
+++ b/tests/003-transaction.phpt
@@ -6,7 +6,7 @@ Test transaction
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 try {
     $db->beginTransaction();

--- a/tests/004-columnmeta.phpt
+++ b/tests/004-columnmeta.phpt
@@ -6,7 +6,7 @@ Test column metadata
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/tests/005-attributes.phpt
+++ b/tests/005-attributes.phpt
@@ -5,7 +5,7 @@ Test setting/getting attributes
 --FILE--
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 var_dump ($db->getAttribute (PDO::ATTR_SERVER_VERSION));
 var_dump ($db->setAttribute (PDO::CASSANDRA_ATTR_NUM_RETRIES, 10));

--- a/tests/006-iterate.phpt
+++ b/tests/006-iterate.phpt
@@ -6,7 +6,7 @@ Test iterating prepared statement
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init ($db, $keyspace);
 

--- a/tests/007-fetchgrouped.phpt
+++ b/tests/007-fetchgrouped.phpt
@@ -6,7 +6,7 @@ Test fetching grouped columns
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init ($db, $keyspace);
 

--- a/tests/008-executemultiple.phpt
+++ b/tests/008-executemultiple.phpt
@@ -7,7 +7,7 @@ Test execute prepared statement multiple times
 
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init ($db, $keyspace);
 

--- a/tests/010-auth.phpt
+++ b/tests/010-auth.phpt
@@ -6,7 +6,7 @@ Test authentication
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 echo "OK";
 
 ?>

--- a/tests/011-persistentconnection.phpt
+++ b/tests/011-persistentconnection.phpt
@@ -7,9 +7,9 @@ Test initialization of persistent connections
 
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password, array (
+$db = new PDO($dsn, $username, $password, array_merge($params, array (
                   PDO::ATTR_PERSISTENT => true
-             ));
+             )));
 
 echo "OK";
 

--- a/tests/012-quoter.phpt
+++ b/tests/012-quoter.phpt
@@ -7,7 +7,7 @@ Test quoting values
 
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 var_dump ($db->quote ("'hello' 'world'"));
 var_dump ($db->quote ("Co'mpl''ex \"st'\"ring"));
 var_dump ($db->quote ("'''''''''", PDO::PARAM_LOB));

--- a/tests/013-errorhandling.phpt
+++ b/tests/013-errorhandling.phpt
@@ -7,7 +7,7 @@ Test different error handling modes
 
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init ($db, $keyspace);
 

--- a/tests/014-affectedrows.phpt
+++ b/tests/014-affectedrows.phpt
@@ -6,7 +6,7 @@ Test number of affected rows
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init ($db, $keyspace);
 

--- a/tests/015-lastinsertid.phpt
+++ b/tests/015-lastinsertid.phpt
@@ -6,7 +6,7 @@ Test last insert id
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init ($db, $keyspace);
 

--- a/tests/016-bindparam.phpt
+++ b/tests/016-bindparam.phpt
@@ -6,7 +6,7 @@ Test binding params
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init ($db, $keyspace);
 

--- a/tests/018-int.phpt
+++ b/tests/018-int.phpt
@@ -6,7 +6,7 @@ Test integers
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/tests/019-uuid.phpt
+++ b/tests/019-uuid.phpt
@@ -6,7 +6,7 @@ Test UUIDs
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/tests/020-types.phpt
+++ b/tests/020-types.phpt
@@ -6,7 +6,7 @@ Test different data types
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/tests/021-cass_bindings.phpt
+++ b/tests/021-cass_bindings.phpt
@@ -8,7 +8,7 @@ UUID tests
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 try {

--- a/tests/022-counters.phpt
+++ b/tests/022-counters.phpt
@@ -6,7 +6,7 @@ Test counters
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init ($db, $keyspace);
 

--- a/tests/023-preserve.phpt
+++ b/tests/023-preserve.phpt
@@ -6,7 +6,7 @@ Test preserving column keys and values
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/tests/024-multiplekeyspaces.phpt
+++ b/tests/024-multiplekeyspaces.phpt
@@ -6,7 +6,7 @@ Test multiple keyspaces
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init($db);
 

--- a/tests/025-activecolumnfamily.phpt
+++ b/tests/025-activecolumnfamily.phpt
@@ -6,7 +6,7 @@ Test that active columnfamily is tracked correctly
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init ($db, $keyspace);
 

--- a/tests/026-bigint.phpt
+++ b/tests/026-bigint.phpt
@@ -10,7 +10,7 @@ if (!extension_loaded ('gmp'))
 
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init($db, $keyspace);
 

--- a/tests/027-startupkeyspace.phpt
+++ b/tests/027-startupkeyspace.phpt
@@ -6,7 +6,7 @@ Test startup keyspace (dbname=...)
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/tests/029-timestamp.phpt
+++ b/tests/029-timestamp.phpt
@@ -6,7 +6,7 @@ Test timestamp type
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/tests/030-ascii_string.phpt
+++ b/tests/030-ascii_string.phpt
@@ -7,7 +7,7 @@ Test special characters in ascii strings
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 pdo_cassandra_init($db, $keyspace);
 
 function display($db, $field) {

--- a/tests/031-consistencylevel.phpt
+++ b/tests/031-consistencylevel.phpt
@@ -8,7 +8,7 @@ Test consistency level set in db handle
 require_once(dirname(__FILE__) . '/config.inc');
 
 // pass consistency param in constructor
-$params = array(PDO::CASSANDRA_ATTR_CONSISTENCYLEVEL => PDO::CASSANDRA_CONSISTENCYLEVEL_ONE);
+$params = array_merge($params, array(PDO::CASSANDRA_ATTR_CONSISTENCYLEVEL => PDO::CASSANDRA_CONSISTENCYLEVEL_ONE));
 $db = new PDO($dsn, $username, $password, $params);
 
 pdo_cassandra_init ($db, $keyspace);

--- a/tests/032-null_value.phpt
+++ b/tests/032-null_value.phpt
@@ -9,7 +9,7 @@ Test null returns on select queries
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 try {

--- a/tests/033-float.phpt
+++ b/tests/033-float.phpt
@@ -8,7 +8,7 @@ FLOAT implementation test
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 try {

--- a/tests/034-collections.phpt
+++ b/tests/034-collections.phpt
@@ -7,7 +7,7 @@ Test collection types
 
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 try {

--- a/tests/035-null-return.phpt
+++ b/tests/035-null-return.phpt
@@ -8,7 +8,7 @@ NULL return test
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 try {

--- a/tests/037-uuid.phpt
+++ b/tests/037-uuid.phpt
@@ -8,7 +8,7 @@ UUID tests
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 try {

--- a/tests/038-decimal.phpt
+++ b/tests/038-decimal.phpt
@@ -8,7 +8,7 @@ Test decimal type
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/tests/039-boolean.phpt
+++ b/tests/039-boolean.phpt
@@ -8,7 +8,7 @@ Boolean related tests
 <?php
 require_once(dirname(__FILE__) . '/config.inc');
 
-$db = new PDO($dsn, $username, $password);
+$db = new PDO($dsn, $username, $password, $params);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 try {

--- a/tests/config.inc-dist
+++ b/tests/config.inc-dist
@@ -7,8 +7,14 @@ $dsn = 'cassandra:host=127.0.0.1;port=9160;cqlversion=3.0.0';
 $username = YourCassandraUSERName;
 $password = YourCassandraPWD;
 
-// Uncomment following line for client-server SSL enabled Cassandra server and set server certificate path.
-//$params = array (PDO::CASSANDRA_ATTR_SSL_CAPATH => YourTrustedCertPath, PDO::CASSANDRA_ATTR_SSL_VERIFY_HOST => 0);
+// Uncomment following block for SSL secured connections between PHP client and Cassandra server and set appropriate values in the array.
+/*
+$params = array (PDO_CASSANDRA_ATTR_SSL_KEY => YourSSLKeyPath,
+		PDO_CASSANDRA_ATTR_SSL_KEY_PASSPHRASE => YourKeyPassPhrase,
+		PDO_CASSANDRA_ATTR_SSL_CERT => YourSSLCertPath,
+		PDO::CASSANDRA_ATTR_SSL_CAPATH => YourTrustedCertPath,
+		PDO::CASSANDRA_ATTR_SSL_VERIFY_HOST => 0);
+*/
 $params = array()
 
 // Warning: the keyspace will be truncated during tests

--- a/tests/config.inc-dist
+++ b/tests/config.inc-dist
@@ -7,6 +7,10 @@ $dsn = 'cassandra:host=127.0.0.1;port=9160;cqlversion=3.0.0';
 $username = YourCassandraUSERName;
 $password = YourCassandraPWD;
 
+// Uncomment following line for client-server SSL enabled Cassandra server and set server certificate path.
+//$params = array (PDO::CASSANDRA_ATTR_SSL_CAPATH => YourTrustedCertPath, PDO::CASSANDRA_ATTR_SSL_VERIFY_HOST => 0);
+$params = array()
+
 // Warning: the keyspace will be truncated during tests
 $keyspace = "phptests";
 

--- a/wikipage-edit.txt
+++ b/wikipage-edit.txt
@@ -4,9 +4,11 @@
 
 	PDO_CASSANDRA_ATTR_SSL_KEY => Use this property to set client SSL private key Only if 'require_client_auth' is 'true' in Cassandra client ecryption options.
 
+	PDO_CASSANDRA_ATTR_SSL_KEY_PASSPHRASE => Use this property to specify passphrase of the SSL key specified using PDO_CASSANDRA_ATTR_SSL_KEY.
+
 	PDO_CASSANDRA_ATTR_SSL_CERT => Use this property to set client public key Only if 'require_client_auth' is 'true' in Cassandra client ecryption options.
 
-	PDO_CASSANDRA_ATTR_SSL_CAPATH => Use this option to set Cassandra Server cert which is already added in server truststore.
+	PDO_CASSANDRA_ATTR_SSL_CAPATH => Use this option to set all trusted certificates.
 
 	PDO_CASSANDRA_ATTR_SSL_VALIDATE => If this option is set, server cert is validated for Trusted CA etc.
 
@@ -21,7 +23,20 @@ $dsn = 'cassandra:host=127.0.0.1;port=9160;cqlversion=3.0.0';
 // set username and password to null for no authentication
 $username = YourCassandraUSERName;
 $password = YourCassandraPWD;
-$params = array (PDO::CASSANDRA_ATTR_SSL_CAPATH => YourTrustedCertPath, PDO::CASSANDRA_ATTR_SSL_VERIFY_HOST => 0);
+
+// For unsecured keys
+//$params = array (PDO_CASSANDRA_ATTR_SSL_KEY => YourSSLKeyPath,
+		   PDO_CASSANDRA_ATTR_SSL_CERT => YourSSLCertPath,
+		   PDO::CASSANDRA_ATTR_SSL_CAPATH => YourTrustedCertPath,
+		   PDO::CASSANDRA_ATTR_SSL_VERIFY_HOST => 0);
+
+// For secured keys
+$params = array (PDO_CASSANDRA_ATTR_SSL_KEY => YourSSLKeyPath,
+		PDO_CASSANDRA_ATTR_SSL_KEY_PASSPHRASE => YourKeyPassPhrase,
+		PDO_CASSANDRA_ATTR_SSL_CERT => YourSSLCertPath,
+		PDO::CASSANDRA_ATTR_SSL_CAPATH => YourTrustedCertPath,
+		PDO::CASSANDRA_ATTR_SSL_VERIFY_HOST => 0);
+
 $db = new PDO($dsn, $username, $password, $params);
 
 2. For the reference, your Cassandra server configuration should look like as follows,
@@ -30,11 +45,9 @@ $db = new PDO($dsn, $username, $password, $params);
 client_encryption_options:
     enabled: true
     keystore: /etc/cassandra/conf/.keystore
-    keystore_password: nmE83^_-qZ
-    # truststore: /etc/cassandra/conf/.truststore
-    # truststore_password: mLzqQ%_zM
-    require_client_auth: false
-    cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]
+    keystore_password: *******
+    truststore: /etc/cassandra/conf/.truststore
+    truststore_password: *******
     # require_client_auth: true
     # Set trustore and truststore_password if require_client_auth is true
     # More advanced defaults below:
@@ -42,11 +55,3 @@ client_encryption_options:
     # algorithm: SunX509
     # store_type: JKS
     # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]
-
-3.You can export your Cassandra server trusted certificate using following command,
-
-keytool -exportcert -rfc -alias <certificate-alias-in-truststore> -file server-cert.pem -keystore /etc/cassandra/conf/.truststore
-
-Note: It requires the server truststore password.
-
-Once you have server-cert.pem, copy it to client host and use with CASSANDRA_ATTR_SSL_CAPATH property in your PHP code.

--- a/wikipage-edit.txt
+++ b/wikipage-edit.txt
@@ -1,0 +1,52 @@
+
+
+1. Following new Attributes have been added for using SSL while communicating with Cassandra which has client_encryption enabled.
+
+	PDO_CASSANDRA_ATTR_SSL_KEY => Use this property to set client SSL private key Only if 'require_client_auth' is 'true' in Cassandra client ecryption options.
+
+	PDO_CASSANDRA_ATTR_SSL_CERT => Use this property to set client public key Only if 'require_client_auth' is 'true' in Cassandra client ecryption options.
+
+	PDO_CASSANDRA_ATTR_SSL_CAPATH => Use this option to set Cassandra Server cert which is already added in server truststore.
+
+	PDO_CASSANDRA_ATTR_SSL_VALIDATE => If this option is set, server cert is validated for Trusted CA etc.
+
+	PDO_CASSANDRA_ATTR_SSL_VERIFY_HOST => If this option is 'true' (1) by default, set it to false for skipping host name verification in server cert. 
+
+	PDO_CASSANDRA_ATTR_SSL_CIPHER => Use this options to set CIPHERS to be supported by your client, which should be super set of server ciphers.
+
+Example PHP code,
+
+$dsn = 'cassandra:host=127.0.0.1;port=9160;cqlversion=3.0.0';
+
+// set username and password to null for no authentication
+$username = YourCassandraUSERName;
+$password = YourCassandraPWD;
+$params = array (PDO::CASSANDRA_ATTR_SSL_CAPATH => YourTrustedCertPath, PDO::CASSANDRA_ATTR_SSL_VERIFY_HOST => 0);
+$db = new PDO($dsn, $username, $password, $params);
+
+2. For the reference, your Cassandra server configuration should look like as follows,
+
+# enable or disable client/server encryption.
+client_encryption_options:
+    enabled: true
+    keystore: /etc/cassandra/conf/.keystore
+    keystore_password: nmE83^_-qZ
+    # truststore: /etc/cassandra/conf/.truststore
+    # truststore_password: mLzqQ%_zM
+    require_client_auth: false
+    cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]
+    # require_client_auth: true
+    # Set trustore and truststore_password if require_client_auth is true
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]
+
+3.You can export your Cassandra server trusted certificate using following command,
+
+keytool -exportcert -rfc -alias <certificate-alias-in-truststore> -file server-cert.pem -keystore /etc/cassandra/conf/.truststore
+
+Note: It requires the server truststore password.
+
+Once you have server-cert.pem, copy it to client host and use with CASSANDRA_ATTR_SSL_CAPATH property in your PHP code.

--- a/wikipage-edit.txt
+++ b/wikipage-edit.txt
@@ -10,7 +10,7 @@
 
 	PDO_CASSANDRA_ATTR_SSL_VALIDATE => If this option is set, server cert is validated for Trusted CA etc.
 
-	PDO_CASSANDRA_ATTR_SSL_VERIFY_HOST => If this option is 'true' (1) by default, set it to false for skipping host name verification in server cert. 
+	PDO_CASSANDRA_ATTR_SSL_VERIFY_HOST => If this option is 'true' (1) by default, set it to false for skipping host name verification in server cert.
 
 	PDO_CASSANDRA_ATTR_SSL_CIPHER => Use this options to set CIPHERS to be supported by your client, which should be super set of server ciphers.
 


### PR DESCRIPTION
This is the change which provides capability for a php client to communicate to a Cassandra server over SSL, by setting certain SSL properties in PDO constructor in the php code. Check changes in tests/config.inc-dist for more information.

Same test suit was used to test this implementation, by just one minor modification in all tests i.e. by adding "params" parameter to PDO constructor and then for SSL based tests, adding new properties to the params array.

All tests with the implementation pass if Cassandra server is configured correctly with key/cert in keystore/truststore. Please refer to wikipage-edit.txt for more details.

Note: If the changes don't compile with Thrift 0.9.1, try using next release version 0.9.2.